### PR TITLE
HDLBits-tb2

### DIFF
--- a/HDLBits/tb2.sv
+++ b/HDLBits/tb2.sv
@@ -1,8 +1,12 @@
 module top_module();
+
+    // variables declaration
     reg clk,in;
     reg [2:0] s;
     wire out;
-	
+
+	// Instantiate the DUT
+    // DUT: q7
     q7 uut(
         .clk(clk),
         .in(in),
@@ -10,14 +14,13 @@ module top_module();
         .out(out)
     );
 
-    // clock: 10-unit period
+    // Clock: 10-unit period
     initial clk = 0;
     always #5 clk = ~clk;
     
     // Input stimulus for in
     initial begin
         in = 0;
-
         #20 in = 1;
         #10 in = 0;
         #10 in = 1;

--- a/HDLBits/tb2.sv
+++ b/HDLBits/tb2.sv
@@ -9,20 +9,24 @@ module top_module();
         .s(s),
         .out(out)
     );
+
+    // clock: 10-unit period
+    initial clk = 0;
+    always #5 clk = ~clk;
     
+    // Input stimulus for in
     initial begin
-    	clk = 0;
         in = 0;
-        s = 3'b010;
+
         #20 in = 1;
         #10 in = 0;
         #10 in = 1;
         #30 in = 0;
     end
 
-    always #5 clk = ~clk; 
-
+    // Stimulus for s
     initial begin
+        s = 3'b010;
         #10 s = 3'b110;
         #10 s = 3'b010;
         #10 s = 3'b111;

--- a/HDLBits/tb2.sv
+++ b/HDLBits/tb2.sv
@@ -1,0 +1,32 @@
+module top_module();
+    reg clk,in;
+    reg [2:0] s;
+    wire out;
+	
+    q7 uut(
+        .clk(clk),
+        .in(in),
+        .s(s),
+        .out(out)
+    );
+    
+    initial begin
+    	clk = 0;
+        in = 0;
+        s = 3'b010;
+        #20 in = 1;
+        #10 in = 0;
+        #10 in = 1;
+        #30 in = 0;
+    end
+
+    always #5 clk = ~clk; 
+
+    initial begin
+        #10 s = 3'b110;
+        #10 s = 3'b010;
+        #10 s = 3'b111;
+        #10 s = 3'b000;
+    end
+
+endmodule


### PR DESCRIPTION
In this PR, I implemented the testbench for the fourth problem, targeting the `q7` module. 
The testbench drives three input signals—`clk`, `in`, and `s`—each using its own `initial ` or `always` block for better separation of concerns and readability. The waveform pattern follows the expected timing diagram, with `clk` generated as a 10-time unit periodic signal, and `in`/`s` values updated at specific simulation times. 